### PR TITLE
Pin ESLint to ^8.57.0 temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "switch:react-18": "SWITCH_NAME=react-18 npm run switch:_",
     "test": "npm run test --if-present --workspaces"
   },
+  "pinDependencies": {
+    "eslint": [
+      "^8.57.0"
+    ]
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

(No changelog for GitHub workflow related changes.)

## Specific changes

> Please list each individual specific change in this pull request.

- `@typescript-eslint/eslint-plugin` requires `eslint@^8.57.0 || ^9.0.0`
   - For some reasons, we need to bump it in 2 phases